### PR TITLE
Added changes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,8 @@ The following workflow is for a new **Helm** operator:
 First, checkout and install the operator-sdk CLI:
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/operator-framework
-$ cd $GOPATH/src/github.com/operator-framework
-$ git clone https://github.com/operator-framework/operator-sdk
-$ cd operator-sdk
+$ go get github.com/operator-framework/operator-sdk
+$ cd $GOPATH/src/github.com/operator-framework/operator-sdk
 $ git checkout master
 $ make dep
 $ make install


### PR DESCRIPTION
The old steps are overcoming the benefits provided by "go get <repo>" command, which automatically clones the repo in "$GOPATH/src/" . Hence, with this commit, I trying to leverage-up those benefits by introducing in "go get <repo>" in README.md .
